### PR TITLE
Works with paperless on non-root

### DIFF
--- a/js/src/components/DocumentDetail.js
+++ b/js/src/components/DocumentDetail.js
@@ -57,7 +57,7 @@ class DocumentDetail extends PaperlessComponent {
 				if (this.state.doc.download_url) {
 					ipcRenderer.send("download", {
 						url:
-							super.getHost() +
+							super.getBaseHost() +
 							this.state.doc.download_url.replace("\\", "")
 					});
 				}
@@ -177,7 +177,7 @@ class DocumentDetail extends PaperlessComponent {
 				<div className="pane-two-third">
 					<spdf.SimplePDF
 						file={
-							super.getHost() +
+							super.getBaseHost() +
 							this.state.doc.download_url.replace("\\", "")
 						}
 					/>

--- a/js/src/components/DocumentItem.js
+++ b/js/src/components/DocumentItem.js
@@ -20,7 +20,7 @@ class DocumentItem extends PaperlessComponent {
 	componentDidMount() {
 		// load the image base64 data
 		super.getDataUri(
-			super.getHost() +
+			super.getBaseHost() +
 				this.props.document.thumbnail_url.replace("\\", ""),
 			result => {
 				this.setState({

--- a/js/src/components/PaperlessComponent.js
+++ b/js/src/components/PaperlessComponent.js
@@ -10,6 +10,10 @@ class PaperlessComponent extends React.Component {
     getHost() {
         return localStorage.getItem("settings.host");
     }
+    getBaseHost(){
+        var re = new RegExp("(https?:\/\/.*)\/.*");
+        return re.exec(localStorage.getItem("settings.host"))[1];
+    }
 
     // GET DATA URI
     getDataUri(url, callback) {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,13 @@
 {
 	"name": "paperless-desktop",
 	"version": "0.0.9",
-	"description":
-		"Desktop app that uses the paperless API to manage your documents",
+	"description": "Desktop app that uses the paperless API to manage your documents",
 	"main": "main.js",
 	"scripts": {
 		"start": "gulp && electron .",
 		"test": "echo \"Error: no test specified\" && exit 1",
-		"package:mac":
-			"gulp && electron-packager ./ Paperless --platform=darwin --arch=all --out ./build --ignore='^/build$' --electron-version 1.4.13 --overwrite --icon=./icon.icns"
+		"package:mac": "gulp && electron-packager ./ Paperless --platform=darwin --arch=all --out ./build --ignore='^/build$' --electron-version 1.4.13 --overwrite --icon=./icon.icns",
+		"package:win": "gulp && electron-packager ./ Paperless --platform=win32 --arch=all --out ./build --ignore='^/build$' --electron-version 1.4.13 --overwrite --icon=./icon.png"
 	},
 	"repository": {
 		"type": "git",
@@ -28,6 +27,7 @@
 		"jquery": "^3.1.1",
 		"moment": "^2.17.1",
 		"other-window-ipc": "^1.3.0",
+		"pdfjs-dist": "1.5.222",
 		"prop-types": "^15.5.8",
 		"react": "^15.4.1",
 		"react-big-calendar": "^0.13.0",
@@ -63,7 +63,11 @@
 		"vinyl-source-stream": "^1.1.0",
 		"watchify": "^3.4.0"
 	},
-	"keywords": ["paperless", "desktop", "electron"],
+	"keywords": [
+		"paperless",
+		"desktop",
+		"electron"
+	],
 	"author": "Thomas Brüggemann",
 	"license": "GPL-3.0",
 	"bugs": {


### PR DESCRIPTION
Additionally, older version of pdfjs for unknown reasons

Basically, simple change to allow non-root locations for paperless
by introducing a getBaseHost() function. Currently powered
with nothing but regex and hope, but it seems to work well enough