### PR TITLE
Fix for not being able to edit empty 'match' fields on tags list

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -257,3 +257,9 @@
 .toolbar-header {
 	-webkit-app-region: drag;
 }
+
+.tags-match {
+	min-height: 1.5em;
+	min-width: 100px;
+	display: block;
+}

--- a/js/src/components/TagsListItem.js
+++ b/js/src/components/TagsListItem.js
@@ -65,6 +65,7 @@ class TagsListItem extends PaperlessComponent {
                         propName="match"
                         change={this.changeProp.bind(this)}
                         classEditing="inplace-edit"
+                        className="tags-match"
                     />
                 </td>
                 <td>


### PR DESCRIPTION
## Describe the changes you made

You previously couldn't edit a tag's `match` field if it was not set. I gave it a min-width, height, and block display so that you can edit it even without content.

## Why were these changes necessary/desired?

Because it didn't work before.

## How can the changes be tested?

You have to have a tag with an empty `match` field. Try and edit it. Previously clicking it did nothing but flash the bar blue, now you can edit it.

## Did you already test the changes?

Yup