### PR TITLE
added "Fuzzy Match" matching algorithm

### DIFF
--- a/js/src/components/TagsListItem.js
+++ b/js/src/components/TagsListItem.js
@@ -12,7 +12,8 @@ class TagsListItem extends PaperlessComponent {
             { id: "1", text: "Any" },
             { id: "2", text: "All" },
             { id: "3", text: "Literal" },
-            { id: "4", text: "Regular Expression" }
+            { id: "4", text: "Regular Expression" },
+            { id: "5", text: "Fuzzy Match" }
         ];
     }
 


### PR DESCRIPTION
## Describe the changes you made

I added the "Fuzzy Match" matching algorithm

## Why were these changes necessary/desired?

Because it broke the Tag listing

## How can the changes be tested?

You have to create a tag with the "Fuzzy Match" matching algorithm in Paperless.
The Tag List in Paperless Desktop then won't work anymore

## Did you already test the changes?

yes
