### PR TITLE
add fields to Correspondent Listing

### DIFF
--- a/js/src/components/CorrespondentsListItem.js
+++ b/js/src/components/CorrespondentsListItem.js
@@ -1,8 +1,22 @@
 import React from "react";
 import PaperlessComponent from "./PaperlessComponent";
-import { RIEInput } from "riek";
+import { RIEInput, RIESelect } from "riek";
 
 class CorrespondentsListItem extends PaperlessComponent {
+    // CONSTRUCTOR
+    constructor(props) {
+        super(props);
+
+        // matching algorithm options
+        this.matching_algorithm = [
+            { id: "1", text: "Any" },
+            { id: "2", text: "All" },
+            { id: "3", text: "Literal" },
+            { id: "4", text: "Regular Expression" },
+            { id: "5", text: "Fuzzy Match" }
+        ];
+    }
+    
     // CHANGE SELECTION
     changeSelection(event) {
         const target = event.target;
@@ -11,6 +25,11 @@ class CorrespondentsListItem extends PaperlessComponent {
 
     // CHANGE PROP
     changeProp(e) {
+        // special select box arrangement
+        if ("matching_algorithm" in e) {
+            e["matching_algorithm"] = parseInt(e["matching_algorithm"].id);
+        }
+
         var data = Object.assign(this.props.correspondent, e);
         this.props.updateCorrespondent(data);
     }
@@ -33,8 +52,26 @@ class CorrespondentsListItem extends PaperlessComponent {
                         classEditing="inplace-edit"
                     />
                 </td>
-                <td>{this.props.correspondent.match}</td>
-                <td>{this.props.correspondent.matching_algorithm}</td>
+                <td>
+                    <RIEInput
+                        value={this.props.correspondent.match}
+                        propName="match"
+                        change={this.changeProp.bind(this)}
+                        classEditing="inplace-edit"
+                        className="correspondents-match"
+                    />
+                </td>
+                <td>
+                    <RIESelect
+                        value={this.matching_algorithm.find(a => {
+                            return parseInt(a.id) ===
+                                this.props.correspondent.matching_algorithm;
+                        })}
+                        propName="matching_algorithm"
+                        change={this.changeProp.bind(this)}
+                        options={this.matching_algorithm}
+                    />
+                </td>
             </tr>
         );
     }


### PR DESCRIPTION
this requires https://github.com/danielquinn/paperless/pull/483

## Describe the changes you made

I added the "match" and "matching_algorithm" fields to the correspondent listing

## Why were these changes necessary/desired?

Because they exist in paperless and should be available here too

## How can the changes be tested?

You have to ...

## Did you already test the changes?

I tested ...
