### PR TITLE
Update package.json to include natives >= 1.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"history": "^1.12.5",
 		"jquery": "^3.1.1",
 		"moment": "^2.17.1",
+                "natives": "^1.1.6",
 		"other-window-ipc": "^1.3.0",
 		"prop-types": "^15.5.8",
 		"react": "^15.4.1",


### PR DESCRIPTION
...so Mac OS X 11+ can run ```npm start``` without gulp acting up.
See https://github.com/gulpjs/gulp/issues/2246

## Describe the changes you made

Added natives >= 1.1.6 to package.json

## Why were these changes necessary/desired?

Breakage of ```gulp``` on mac os x

## How can the changes be tested?

```npm install && npm start``` without change v.s. with change

## Did you already test the changes?

Yes, else I wouldn't be able to run paperless-desktop...